### PR TITLE
Add SIGINT handling.

### DIFF
--- a/src/ricardo.js
+++ b/src/ricardo.js
@@ -91,3 +91,8 @@ client.on('message', msg => {
 
 
 client.login(auth.token);
+
+
+process.on('SIGINT', function() {
+    process.exit();
+});


### PR DESCRIPTION
Allows the node application to be killed more easily.

This may help with stopping the VM.